### PR TITLE
[gw] fix clone link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Clone GenomeWorks
 ```bash
-git clone --recursive ssh://git@gitlab-master.nvidia.com:12051/genomics/GenomeWorks.git
+git clone --recursive git@github.com:clara-genomics/GenomeWorks.git
 ```
 
 ## Build GenomeWorks


### PR DESCRIPTION
Link to clone in README was outdated. Fixed it to match new GitHub setup.