### PR TITLE
[cudapoa] support single sequence case

### DIFF
--- a/cudapoa/src/cudapoa_generate_consensus.cu
+++ b/cudapoa/src/cudapoa_generate_consensus.cu
@@ -89,7 +89,7 @@ __device__
             score_node_id += scores[predecessors[node_id]];
         }
 
-        if (max_score < score_node_id)
+        if (max_score <= score_node_id)
         {
             max_score    = score_node_id;
             max_score_id = node_id;


### PR DESCRIPTION
when a graph has just a single sequence with same weights for all nodes,
the consensus is just the graph itself. this case throwing an error earlier
in the consensus kernel. fixing this bug.