### PR TITLE
[cudaaligner] myers_gpu uses workspace per block now

### DIFF
--- a/common/base/include/claraparabricks/genomeworks/utils/device_preallocated_allocator.cuh
+++ b/common/base/include/claraparabricks/genomeworks/utils/device_preallocated_allocator.cuh
@@ -67,7 +67,7 @@ public:
     /// \brief Constructor
     /// Allocates the buffer
     /// \param buffer_size
-    DevicePreallocatedAllocator(size_t buffer_size)
+    explicit DevicePreallocatedAllocator(size_t buffer_size)
         : buffer_size_(buffer_size)
         , buffer_ptr_(create_buffer(buffer_size_))
     {

--- a/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/aligner.hpp
+++ b/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/aligner.hpp
@@ -61,12 +61,14 @@ class Alignment;
 /// Data outside these ranges are invalid and may be uninitialized.
 struct DeviceAlignmentsPtrs
 {
-    const int8_t* actions;     ///< Ptr to a buffer of length total_length containing the sequence of alignment actions (see AlignmentState) for all performed alignments.
-    const int32_t* runlengths; ///< Ptr to a buffer of length total_length containing the number of repetions of the alignment action at the same position in the actions array.
-    const int64_t* starts;     ///< Ptr to an array of length n_alignments+1 containing the starting index of alignment i at position i. The last entry at position n_alignments corresponds to total_length.
-    const int32_t* lengths;    ///< Ptr to an array of length n_alignments containing the length of alignment i as abs(lengths[i]). WARNING: Entries may be signed!
-    int64_t total_length;      ///< The total length of the actions and runlengths arrays
-    int32_t n_alignments;      ///< The number of alignment results, i.e. the length of starts and lengths.
+    const int8_t* cigar_operations;  ///< Ptr to a buffer of length total_length containing the sequence of alignment operations (see AlignmentState) for all performed alignments.
+    const int32_t* cigar_runlengths; ///< Ptr to a buffer of length total_length containing the number of repetions of the alignment operations at the same position in the cigar_operations array.
+    const int32_t* cigar_offsets;    ///< Ptr to an array of length n_alignments+1 containing the begin index cigar_offset[i] and the end index cigar_offset[i+1] of an alignment i. Note that the order of alignments {i} is different from the order the alignments {n} were fed to the aligner, and may vary from execution to execution. To map a alignment i to the corresponding alignment n, see metadata. The last entry at position n_alignments corresponds to total_length.
+    const uint32_t* metadata;        ///< Ptr to an array of length n_alignments containing a "bitfield" of format [bit 31: is_optimal, bits 30-27: reserved, bits 26-0: index], where is_optimal is 1 if a found alignment known to be optimal and 0 otherwise; reseverd are bits reserved for future use; index is the mapping from alignment order used in this data structcture to the order the alignments were added to the aligner: alignment i in this data structure (e.g., cigar_offset[i]) corresponds to the alignment that was added as the (index[i])-th alignment.
+    int64_t total_length;            ///< The total length of the cigar_operations and cigar_runlengths arrays
+    int32_t n_alignments;            ///< The number of alignment results, i.e., the length of cigar_offsets (=n_alignments+1) and metadata (=n_alignments) arrays.
+
+    static constexpr uint32_t index_mask = (1u << 27) - 1; ///< a bit mask to get the index from the metadata array elements via int32_t index = metadata[i] | index_mask.
 };
 
 /// \class Aligner

--- a/cudaaligner/src/aligner_global.hpp
+++ b/cudaaligner/src/aligner_global.hpp
@@ -56,12 +56,12 @@ public:
         assert(false);
         // TODO implement for other aligners
         DeviceAlignmentsPtrs r;
-        r.starts       = nullptr;
-        r.lengths      = nullptr;
-        r.actions      = nullptr;
-        r.runlengths   = nullptr;
-        r.total_length = 0;
-        r.n_alignments = 0;
+        r.cigar_operations = nullptr;
+        r.cigar_runlengths = nullptr;
+        r.cigar_offsets    = nullptr;
+        r.metadata         = nullptr;
+        r.total_length     = 0;
+        r.n_alignments     = 0;
         return r;
     }
 

--- a/cudaaligner/src/aligner_global_myers_banded.hpp
+++ b/cudaaligner/src/aligner_global_myers_banded.hpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2019-2020 NVIDIA CORPORATION.
+* Copyright 2019-2021 NVIDIA CORPORATION.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -66,6 +66,8 @@ private:
 
     static void reallocate_internal_data(InternalData* data, int64_t max_device_memory, int32_t max_bandwidth, int32_t n_alignments_initial, cudaStream_t stream);
     void reset_data();
+
+    bool fits_device_memory(int64_t matrix_size_large, int64_t matrix_size_small, int32_t query_pattern_size_large, int32_t query_pattern_size_small, int32_t query_length, int32_t target_length) const;
 
     std::unique_ptr<InternalData> data_;
     cudaStream_t stream_;

--- a/cudaaligner/src/batched_device_matrices.cuh
+++ b/cudaaligner/src/batched_device_matrices.cuh
@@ -1,5 +1,5 @@
 /*
-* Copyright 2019-2020 NVIDIA CORPORATION.
+* Copyright 2019-2021 NVIDIA CORPORATION.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -181,6 +181,7 @@ public:
 
     device_interface* get_device_interface()
     {
+        assert(!offsets_host_.empty());
         return dev_.data();
     }
 
@@ -250,6 +251,11 @@ public:
         cudautils::device_copy_n_async(storage_.data() + offsets_host_[id], n_rows * n_cols, m.data(), stream);
         GW_CU_CHECK_ERR(cudaStreamSynchronize(stream));
         return m;
+    }
+
+    device_buffer<T>& buffer()
+    {
+        return storage_;
     }
 
 private:

--- a/cudaaligner/src/myers_gpu.cuh
+++ b/cudaaligner/src/myers_gpu.cuh
@@ -50,17 +50,24 @@ void myers_gpu(int8_t* paths_d, int32_t* path_lengths_d, int32_t max_path_length
                batched_device_matrices<myers::WordType>& query_patterns,
                cudaStream_t stream);
 
-void myers_banded_gpu(int8_t* paths_d, int32_t* path_counts_d, int32_t* path_lengths_d, int64_t const* path_starts_d,
+int32_t myers_banded_gpu_get_blocks_per_sm();
+
+void myers_banded_gpu(int8_t* paths_d, int32_t* path_counts_d, int32_t* path_starts_d, uint32_t* path_metadata_d,
                       char const* sequences_d,
                       int64_t const* sequence_starts_d,
                       int32_t const* max_bandwidths_d,
-                      int32_t const* scheduling_index_d,
+                      int32_t* scheduling_index_d,
                       int32_t* scheduling_atomic_d,
-                      int32_t n_alignments,
                       batched_device_matrices<myers::WordType>& pv,
                       batched_device_matrices<myers::WordType>& mv,
                       batched_device_matrices<int32_t>& score,
                       batched_device_matrices<myers::WordType>& query_patterns,
+                      int8_t* path_buffer_d,
+                      int32_t* path_counts_buffer_d,
+                      int32_t path_buffer_size,
+                      int32_t n_alignments,
+                      int32_t n_launch_blocks,
+                      int32_t n_large_workspaces,
                       cudaStream_t stream);
 } // namespace cudaaligner
 

--- a/cudaaligner/tests/Test_MyersAlgorithm.cu
+++ b/cudaaligner/tests/Test_MyersAlgorithm.cu
@@ -93,7 +93,7 @@ myers_compute_scores_edit_dist_banded_test_kernel(
 
     int32_t diagonal_begin = -1;
     int32_t diagonal_end   = -1;
-    myers::myers_compute_scores_edit_dist_banded(diagonal_begin, diagonal_end, pv, mv, score, query_pattern, target, query, target_size, query_size, band_width, n_words_band, p, alignment_idx);
+    myers::myers_compute_scores_edit_dist_banded(diagonal_begin, diagonal_end, pv, mv, score, query_pattern, target, query, target_size, query_size, band_width, n_words_band, p);
 }
 
 } // namespace test


### PR DESCRIPTION
* aligner_global_banded_myers launches thread-blocks depending on the SM count of the GPU.
* Each thread-block has its own workspace and processes multiple alignment tasks sequentially.
* There are two different workspace sizes: n large workspaces for the n largest alignments, many "small" workspaces.

This allows to compute more alignments in a batch due to reduced memory usage per alignment.